### PR TITLE
fix(cofig): arreglo en configuracion de conexion a la base de datos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+DB_HOST=aws-1-sa-east-1.pooler.supabase.com
+DB_PORT=5432
+DB_NAME=postgres
+DB_USER=postgres.emgmibetbcbyvkcnpubd
+DB_PASSWORD=
+DB_POOL_MODE=session

--- a/src/app.js
+++ b/src/app.js
@@ -38,7 +38,7 @@ const PORT = process.env.PORT || 4000;
 app.listen(PORT, async () => {
   console.log(`Servidor corriendo en puerto ${PORT}`);
   try {
-    // await sequelize.authenticate();    ⚠️ ACTUALIZAR CONEXIÓN CUANDO SE CREE LA DB 
+    await sequelize.authenticate();  
     console.log("Conexión a la base de datos exitosa ✅");
   } catch (error) {
     console.error("Error al conectar DB ❌:", error);

--- a/src/config/database.js
+++ b/src/config/database.js
@@ -10,6 +10,13 @@ export const sequelize = new Sequelize(
   {
     host: process.env.DB_HOST,
     dialect: "postgres",
+    pool: {
+      max: 10,          // Máximo de conexiones en el pool
+      min: 0,           // Mínimo de conexiones
+      acquire: 30000,   // Tiempo máximo (ms) para adquirir conexión
+      idle: 10000,      // Tiempo máximo (ms) que una conexión puede estar inactiva
+    },
+    port: process.env.DB_PORT,
     logging: false,
   }
 );


### PR DESCRIPTION
En Supabase hay tres tipos de conexiones: Direct, Transaction Pooler y Session Pooler. Primero intente establecer conexión de la forma Direct pero no me encontraba el host. Vi que la razón podía ser que mi pc no tiene soporte IPv6, que es obligatorio en este tipo de conexión. El mismo Supabase recomienda utilizar la forma Session Pooler para conexiones IPv4, asi que tuve que agregar unas modificaciones para que se conecte por este modo. No se si les parece bien esta forma de conectarse a la base de datos o es necesario buscar la forma de conectarse con la forma Direct. Mientras les comparto esta solucion